### PR TITLE
Remove subtype and add tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "signhere"
-version = "0.2.0"
+version = "0.3.0"
 description = ""
 authors = ["Your Name <you@example.com>"]
 license = "MIT"

--- a/tests/test_dynamic_text_adding.py
+++ b/tests/test_dynamic_text_adding.py
@@ -1,0 +1,43 @@
+import pytest
+from io import BytesIO
+
+from fitz import Document
+
+from signhere.utils import add_text_to_pdf
+
+PAGES_TO_TEST = 64
+
+
+def blank_call(*args, **kwargs):
+    return add_text_to_pdf(None, None, *args, **kwargs)
+
+
+def test_sanity():
+    invalid_kwargs = [
+        {"page_num": -1},
+        {"x": -1},
+        {"y": -1},
+    ]
+
+    for kwargs in invalid_kwargs:
+        with pytest.raises(AssertionError):
+            assert blank_call(**kwargs)
+
+
+def test_adding_valid_text():
+    document = Document()
+    document.insertPage(-1, text="(watermark)", width=32, height=32)
+
+    for page_num in range(0, PAGES_TO_TEST):
+        document.insertPage(-1, text=f"This is page number {page_num}")
+
+    for page_num in range(0, PAGES_TO_TEST):
+        assert add_text_to_pdf(
+            document,
+            "test",
+            page_num=page_num + 1,
+            x=64,
+            y=64,
+            x_offset=page_num / 100,
+            y_offset=page_num / 100,
+        )

--- a/tests/test_multiple_adding.py
+++ b/tests/test_multiple_adding.py
@@ -1,0 +1,53 @@
+import pytest
+from io import BytesIO
+
+from PIL import Image
+from fitz import Document
+
+from signhere.utils import add_images_to_pdf
+
+PAGES_TO_TEST = 64
+
+
+PLACEMENT_SETTINGS = {
+    "image": {
+        "max_y": 50,
+        "max_x": 50,
+    },
+    "text": {},
+}
+
+DYNAMIC_TEXT = {"text__name": "test name"}
+
+
+def test_adding_valid_image():
+    document = Document()
+    document.insertPage(-1, text="(watermark)", width=32, height=32)
+
+    img = Image.new("RGB", (5, 10), color="red")
+    watermark = BytesIO()
+    img.save(watermark, format="PNG")
+
+    def img_loader(name):
+        return img
+
+    for page_num in range(0, PAGES_TO_TEST):
+        document.insertPage(-1, text=f"This is page number {page_num}")
+
+    metadata = []
+    for page_num in range(0, PAGES_TO_TEST):
+        metadata.append(
+            {
+                f"image__{page_num}": [[0, 0]],
+                f"text__name": [[50, 50]],
+            }
+        )
+
+    assert add_images_to_pdf(
+        document,
+        metadata,
+        img_loader,
+        PLACEMENT_SETTINGS,
+        DYNAMIC_TEXT,
+        ["text"],
+    )


### PR DESCRIPTION
The subtypes were confusing and weren't really useful since we would override the image settings dictionary and not update it so it wasn't even using any of the data from the "super" type. The one thing that subtypes allowed was to have multiple placement positions for dynamic text. To still support this instead of having the entry in the placement settings always be "text" instead the user passes in a list of types that will be treated as dynamic text instead of an image. 

Changed the ordering of some of the arguments for `add_images_to_pdf` because I changed which ones could be optional.