### PR TITLE
Revert changes to subtypes

### DIFF
--- a/signhere/utils.py
+++ b/signhere/utils.py
@@ -1,5 +1,5 @@
 """
-This module includes functions to insert images and text into PDF documents. This was originally aimed for inserting signatures as images into legal documentation. It also supports inserting text so that text can be added for answers to questions. This was used for inserting personal information and dates into documents. 
+This module includes functions to insert images and text into PDF documents. This was originally aimed for inserting signatures as images into legal documentation. It also supports inserting text so that text can be added for answers to questions. This was used for inserting personal information and dates into documents.
 """
 
 import re
@@ -17,15 +17,14 @@ DEFAULT_PLACEMENT_SETTINGS = {
     "max_x": 0,
     "max_y": 0,
     "x_scalar": 1,
-    "y_scalar": 1
+    "y_scalar": 1,
 }
 """
 Constant dictionary that describes the default values for placing an image into the PDF
 """
 
 
-ImageSettings = NewType(
-"ImageSettings", Dict[str, Union[int, float]])
+ImageSettings = NewType("ImageSettings", Dict[str, Union[int, float]])
 """
 An alias for the dictionary used for image settings. The following keys are required
 - x_offset: A float offset in x of where to place the image
@@ -77,7 +76,9 @@ def make_image_name(img_type: str, name: str):
         return f"{img_type}{SEPARATOR}{name}"
 
 
-def make_text_name(description: str, person: Optional[str] = None, sub_type: Optional[str] = None):
+def make_text_name(
+    description: str, person: Optional[str] = None, sub_type: Optional[str] = None
+):
     """
     Helper function for creating names for dynamic text that includes their description, the person the field is for, and the sub type
     :param description: Description of the text field
@@ -238,7 +239,7 @@ def _get_img_data(
     if split[-1] in img_settings:
         img_name = SEPARATOR.join([s for s in split[:-1] if s])
         img_data.update(img_settings[split[-1]])
-        
+
     return img_name, img_type, img_data
 
 

--- a/signhere/utils.py
+++ b/signhere/utils.py
@@ -45,7 +45,7 @@ PlacementSettings = NewType(
 """
 Dictionary that is used as default values for image settings. The keys should be the image type (which should be part of the image name). The value should be a ImageSettings dictionary. In addition to the ImageSettings keys there can be an additional key where the key value is a string representing the "sub-type" and the value is another ImageSettings dictionary.
 
-The image type of DYNAMIC_TEXT is a special key that will be applied to text (instead of images) inserted. Subtypes can be used under the DYNAMIC_TEXT entry like the other image types. 
+The image type of DYNAMIC_TEXT is a special key that will be applied to text (instead of images) inserted. Subtypes can be used under the DYNAMIC_TEXT entry like the other image types.
 
 All images type need to be in this dictionary or the "image" will be treated as dynamic text.
 """
@@ -59,7 +59,7 @@ Separator between parts of image and dynamic text names.
 
 DYNAMIC_TEXT = "text"
 """
-Constant used to separate the "type" of the image and the name of the image. The type is used to lookup the placement settings 
+Constant used to separate the "type" of the image and the name of the image. The type is used to lookup the placement settings
 """
 
 
@@ -77,17 +77,17 @@ def make_image_name(img_type: str, name: str):
 
 
 def make_text_name(
-    description: str, person: Optional[str] = None, sub_type: Optional[str] = None
+    description: str, role: Optional[str] = None, sub_type: Optional[str] = None
 ):
     """
-    Helper function for creating names for dynamic text that includes their description, the person the field is for, and the sub type
+    Helper function for creating names for dynamic text that includes their description, the role of the person the field is for, and the sub type
     :param description: Description of the text field
-    :param person: The description of the person the text field is for, optional
+    :param role: The role of the person the text field is for, optional
     :param sub_type: The sub type for looking up the placement settings, optional
     """
-    person_str = f"{SEPARATOR}{person}" if person else ""
+    role_str = f"{SEPARATOR}{role}" if role else ""
     sub_type_str = f"{SEPARATOR}{sub_type}" if sub_type else ""
-    return f"{description}{person_str}{sub_type_str}"
+    return f"{description}{role_str}{sub_type_str}"
 
 
 def add_images_to_pdf(

--- a/tests/test_dynamic_text_adding.py
+++ b/tests/test_dynamic_text_adding.py
@@ -1,5 +1,4 @@
 import pytest
-from io import BytesIO
 
 from fitz import Document
 

--- a/tests/test_multiple_adding.py
+++ b/tests/test_multiple_adding.py
@@ -17,10 +17,7 @@ PLACEMENT_SETTINGS = {
     "text": {},
 }
 
-DYNAMIC_TEXT = {
-    "name__test": "test name",
-    "date": "9/12/2019"
-}
+DYNAMIC_TEXT = {"name__test": "test name", "date": "9/12/2019"}
 
 
 def test_adding_multiple_images_and_text():
@@ -42,8 +39,8 @@ def test_adding_multiple_images_and_text():
         metadata.append(
             {
                 f"image__{page_num}": [[0, 0]],
-                f"name__test": [[50, 50]],
-                f"date__test": [[10, 10]],
+                "name__test": [[50, 50]],
+                "date__test": [[10, 10]],
             }
         )
 

--- a/tests/test_multiple_adding.py
+++ b/tests/test_multiple_adding.py
@@ -17,10 +17,13 @@ PLACEMENT_SETTINGS = {
     "text": {},
 }
 
-DYNAMIC_TEXT = {"text__name": "test name"}
+DYNAMIC_TEXT = {
+    "name__test": "test name",
+    "date": "9/12/2019"
+}
 
 
-def test_adding_valid_image():
+def test_adding_multiple_images_and_text():
     document = Document()
     document.insertPage(-1, text="(watermark)", width=32, height=32)
 
@@ -39,7 +42,8 @@ def test_adding_valid_image():
         metadata.append(
             {
                 f"image__{page_num}": [[0, 0]],
-                f"text__name": [[50, 50]],
+                f"name__test": [[50, 50]],
+                f"date__test": [[10, 10]],
             }
         )
 
@@ -47,7 +51,6 @@ def test_adding_valid_image():
         document,
         metadata,
         img_loader,
-        PLACEMENT_SETTINGS,
         DYNAMIC_TEXT,
-        ["text"],
+        PLACEMENT_SETTINGS,
     )


### PR DESCRIPTION
After trying to integrate this library into the project it was removed from I realized we need the expected parameters to be the same. This means that metadata entries for dynamic text won't have their type at the beginning of their names and sub types are reintroduced. I did update some of the variable names. Also changed it so subtypes update the placement settings instead of just replacing them. 